### PR TITLE
Add coverage reporting and badge

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+source = src

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pyMOFL: Python Modular Optimization Function Library
 
+![coverage](coverage.svg)
+
 A composable optimization function library for benchmarking optimization algorithms.
 
 ## Overview
@@ -195,6 +197,10 @@ Mathematically:
 - `RotatedFunction(ShiftedFunction(base))` computes `f(R·x-s)`
 
 These expressions are not mathematically equivalent due to the non-commutativity of vector rotation and subtraction.
+
+## Test Coverage
+
+Run `scripts/generate_coverage.sh` to execute the test suite, generate `coverage.xml`, and update `coverage.svg`.
 
 ## License
 

--- a/coverage.svg
+++ b/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#e05d44" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">8%</text>
+        <text x="80" y="14">8%</text>
+    </g>
+</svg>

--- a/scripts/generate_coverage.sh
+++ b/scripts/generate_coverage.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Generate coverage report and badge
+coverage run -m pytest
+coverage xml -i
+coverage-badge -o coverage.svg -f


### PR DESCRIPTION
## Summary
- generate coverage report with `scripts/generate_coverage.sh`
- store report settings in `.coveragerc`
- add `coverage.svg` badge and reference in README

## Testing
- `coverage run -m pytest` *(fails: 30 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f16ffbc832dbcf37735b0c165f4